### PR TITLE
Fix for overwriting existing session

### DIFF
--- a/rethinkstore.go
+++ b/rethinkstore.go
@@ -124,7 +124,7 @@ func (s *RethinkStore) save(session *sessions.Session) error {
 	if age == 0 {
 		age = s.DefaultMaxAge
 	}
-	_, err = r.Table(s.Table).Insert(RethinkSession{Id: session.ID, Session: buf.Bytes()}).Run(s.Rethink)
+	_, err = r.Table(s.Table).Get(session.ID).Replace(RethinkSession{Id: session.ID, Session: buf.Bytes()}).Run(s.Rethink)
 	return err
 }
 


### PR DESCRIPTION
Instead of inserting (which fails silently if the session is already saved in the database), we use `Replace()` which inserts if the record doesn't exist, but replaces the old one if it exists.
